### PR TITLE
Automatically add new devices to navbar and sort them

### DIFF
--- a/assets/js/components/NavBar.js
+++ b/assets/js/components/NavBar.js
@@ -91,7 +91,7 @@ class NavBar extends Component {
   }
 
   render() {
-    const { devices, names, selectDevice, selectedDevice, receivedNewDevice, findDevice, loading } = this.props
+    const { devices, names, selectDevice, selectedDevice, findDevice, loading } = this.props
     const { show } = this.state
 
     return (
@@ -108,11 +108,6 @@ class NavBar extends Component {
                   {
                     loading && (
                       <p style={styles.tipSmallContainer}>Loading selected device...</p>
-                    )
-                  }
-                  {
-                    !loading && receivedNewDevice && (
-                      <p style={{ ...styles.tipSmallContainer, marginTop: 8 }}>New devices found, please reload the page to refresh device list</p>
                     )
                   }
                 </div>
@@ -148,10 +143,6 @@ class NavBar extends Component {
                   loading && (
                     <p style={{...styles.paddingBox, ...styles.tip }}>Loading selected device...</p>
                   )
-                }
-
-                {
-                  !loading && receivedNewDevice && <p style={{...styles.paddingBox, ...styles.tip }}>New devices found, please reload the page to refresh device list</p>
                 }
 
                 <div style={{ overflow: 'scroll', maxHeight: 'calc(100vh - 190px)' }}>

--- a/assets/js/pages/MapScreen.js
+++ b/assets/js/pages/MapScreen.js
@@ -72,7 +72,6 @@ class MapScreen extends React.Component {
       chartType: null,
       showHotspots: true,
       highlightHotspoted: null,
-      receivedNewDevice: false,
       transmittingDevices: {},
       loading: false,
     }
@@ -124,13 +123,16 @@ class MapScreen extends React.Component {
       const index = findIndex(this.state.devices, { device_id: d.device_id })
       if (devices[index]) {
         devices[index].created_at = d.created_at
+        devices.sort(function(a,b){
+          return new Date(b.created_at) - new Date(a.created_at);
+        });
         this.setState({ devices })
 
         const { transmittingDevices } = this.state
         transmittingDevices[d.device_id] = [Number(d.lon), Number(d.lat)]
         this.setState({ transmittingDevices })
       } else {
-        if (this.state.devices.length > 0 && !this.state.receivedNewDevice) this.setState({ receivedNewDevice: true })
+        this.loadDevices();
       }
     })
   }
@@ -270,7 +272,7 @@ class MapScreen extends React.Component {
   }
 
   render() {
-    const { devices, mapCenter, selectedDevice, packets, lastPacket, hotspots, chartType, showHotspots, highlightedHotspot, receivedNewDevice, transmittingDevices, showSignUp } = this.state
+    const { devices, mapCenter, selectedDevice, packets, lastPacket, hotspots, chartType, showHotspots, highlightedHotspot, transmittingDevices, showSignUp } = this.state
 
     return (
       <div style={{ flex: 1 }}>
@@ -401,7 +403,6 @@ class MapScreen extends React.Component {
           selectDevice={this.selectDevice}
           findDevice={this.findDevice}
           selectedDevice={selectedDevice}
-          receivedNewDevice={receivedNewDevice}
         />
 
         {

--- a/lib/cargo_elixir/payloads/payloads.ex
+++ b/lib/cargo_elixir/payloads/payloads.ex
@@ -51,6 +51,13 @@ defmodule CargoElixir.Payloads do
              |> Map.put(:elevation, 0)
              |> Map.put(:speed, speed)
              |> Map.put(:battery, battery)
+        _ ->
+            attrs
+              |> Map.put(:lat, 0)
+              |> Map.put(:lon, 0)
+              |> Map.put(:elevation, 0)
+              |> Map.put(:speed, 0)
+              |> Map.put(:battery, 0)
     end
     attrs = if attrs.lat > 90 or attrs.lat < -90 do 
       attrs |> Map.put(:lat, 0)


### PR DESCRIPTION
When a device not already in the left navbar sends data, the navbar now automatically updates itself rather than prompting the user to refresh the page. The navbar is also re-sorted by `created_at` date everytime a new payload is received, as previously this was only done on the initial API request to the server.