### PR TITLE
all payloads route

### DIFF
--- a/lib/cargo_elixir/payloads/payloads.ex
+++ b/lib/cargo_elixir/payloads/payloads.ex
@@ -147,6 +147,14 @@ defmodule CargoElixir.Payloads do
     Repo.all(query)
   end
 
+  def get_all_payloads(oui) do
+    time_limit = DateTime.utc_now() |> DateTime.add(-3600, :second)
+    query = from p in Payload,
+      where: (p.oui == ^oui and p.created_at > ^time_limit),
+      select: %{ device_id: p.device_id, lat: p.lat, lon: p.lon, created_at: p.created_at }
+    Repo.all(query)
+  end
+
   def get_currently_transmitting() do
     current_unix = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_unix()
     date_threshold = DateTime.from_unix!(current_unix - 120)

--- a/lib/cargo_elixir_web/controllers/payload_controller.ex
+++ b/lib/cargo_elixir_web/controllers/payload_controller.ex
@@ -27,6 +27,12 @@ defmodule CargoElixirWeb.PayloadController do
     conn |> json(payloads)
   end
 
+  # return all payloads for an oui for the past hour
+  def get_payloads(conn, %{"oui" => oui }) do
+    payloads = Payloads.get_all_payloads(oui)
+    conn |> json(payloads)
+  end
+
   def get_stats(conn, %{ "time" => time }) do
     currently_transmitting = Payloads.get_currently_transmitting() |> List.first()
     devices_transmitted = Payloads.get_device_stats(time) |> List.first()

--- a/lib/cargo_elixir_web/router.ex
+++ b/lib/cargo_elixir_web/router.ex
@@ -18,6 +18,7 @@ defmodule CargoElixirWeb.Router do
     pipe_through :api
 
     get "/oui/:oui", PayloadController, :get_devices
+    get "/oui/:oui/payloads", PayloadController, :get_payloads
     get "/devices/:id", PayloadController, :get_payloads
     options "/oui/:oui", PayloadController, :options
     options "/devices/:id", PayloadController, :options


### PR DESCRIPTION
adds a route that returns all payloads for an oui for the past hour. we'll use this in the sxsw site to fetch the last hour's breadcrumbs