### PR TITLE
Filter Device list by device Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Cargo is a visualization tool for asset trackers. As part of our strategy we are making this application available as open source.
 
-Helium Console has a pre-built Console integration that makes it easy to quickly view a tracker’s physical location. 
+Helium Console has a pre-built Console integration that makes it easy to quickly view a tracker’s physical location.
 
 ## Development Environment
 
@@ -13,6 +13,7 @@ To start your Phoenix server:
   * Install dependencies with `mix deps.get`
   * Create and migrate your database with `mix ecto.setup`
   * Install Node.js dependencies with `cd assets && yarn`
+  * Navigate back to root directory with `cd ..`
   * Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
@@ -29,3 +30,30 @@ Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
   * Run with `docker-compose up`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+
+
+## Common Errors
+
+### Node Version
+
+The error `[error] Task #PID<0.470.0> started from CargoElixirWeb.Endpoint terminating` is often the result of the incorrect Node version being used.
+
+**Current Solution:** use Node v16, tools like `nvm` are great for switching verions in your developer environment
+
+**Walkthrough:**
+1. verify current Node version with `node --version`
+2. install `nvm` with
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+source ~/.nvm/nvm.sh
+```
+
+3. Switch Node version with:
+
+```bash
+nvm install 16
+nvm use 16
+```
+
+4. verify Node version did switch to v16 with `node --version`

--- a/assets/js/components/NavBar.js
+++ b/assets/js/components/NavBar.js
@@ -85,7 +85,7 @@ class NavBar extends Component {
       show: true,
       toggleChecked: false
     }
-    this.toggle = this.toggle.bind(this)    
+    this.toggle = this.toggle.bind(this)
     this.toggleMappers = this.toggleMappers.bind(this)
   }
 
@@ -101,6 +101,19 @@ class NavBar extends Component {
   render() {
     const { devices, names, selectDevice, selectedDevice, findDevice, loading, onSearchChange } = this.props
     const { show } = this.state
+
+    // filter devices to return only 1 of each basd on `device.name` attribute
+    const uniqueDevices = devices.filter((device => {
+      const seenNames = new Set();
+      return device => {
+        if (seenNames.has(device.name)) {
+          return false; // Skip if the name is already seen
+        } else {
+          seenNames.add(device.name); // Mark the name as seen
+          return true; // Include this device
+        }
+      };
+    })());
 
     return (
       <Media queries={{
@@ -124,11 +137,11 @@ class NavBar extends Component {
                 <div style={{ display: 'flex', flexDirection: 'row', overflow: 'auto' }}>
                   <div style={{ borderBottom: '1px solid #D3D3D3', alignItems: 'center', display: 'flex' }}>
                     <div style={{ width: 200, paddingLeft: 8, paddingRight: 8 }}>
-                      <SearchBar devices={devices} onSearchChange={onSearchChange}/>
+                      <SearchBar devices={uniqueDevices} onSearchChange={onSearchChange}/>
                     </div>
                   </div>
 
-                  {devices.map((d, i) =>
+                  {uniqueDevices.map((d, i) =>
                     <div style={{ borderLeft: '1px solid #D3D3D3' }}>
                       <NavBarRow key={d.device_id} device={d} name={names[i]} selectDevice={selectDevice} selectedDevice={selectedDevice} />
                     </div>
@@ -151,12 +164,12 @@ class NavBar extends Component {
                   </div>
 
                   <div style={{ padding: 16, borderBottom: '1px solid #D3D3D3' }}>
-                    <SearchBar devices={devices} onSearchChange={onSearchChange}/>
+                    <SearchBar devices={uniqueDevices} onSearchChange={onSearchChange}/>
                   </div>
                 </div>
 
                 <div style={{ overflow: 'scroll', maxHeight: 'calc(100vh - 190px)' }}>
-                  { show && devices.map((d, i) =>
+                  { show && uniqueDevices.map((d, i) =>
                     <NavBarRow key={d.device_id} device={d} name={names[i]} selectDevice={selectDevice} selectedDevice={selectedDevice} />
                   )}
                 </div>

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,7 +5,7 @@
 # is restricted to this project.
 
 # General application configuration
-use Mix.Config
+import Config
 
 config :cargo_elixir,
   ecto_repos: [CargoElixir.Repo]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # Configure your database
 config :cargo_elixir, CargoElixir.Repo,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # For production, don't forget to configure the url host
 # to something meaningful, Phoenix uses this information

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -3,7 +3,7 @@
 # hardcode secrets, although such is generally not
 # recommended and you have to remember to add this
 # file to your .gitignore.
-use Mix.Config
+import Config
 
 database_url =
   System.get_env("DATABASE_URL") ||
@@ -34,6 +34,6 @@ config :cargo_elixir, CargoElixirWeb.Endpoint,
   force_ssl: [rewrite_on: [:x_forwarded_proto]],
   cache_static_manifest: "priv/static/cache_manifest.json",
   secret_key_base: secret_key_base
-  
+
 
 config :cargo_elixir, console_stats_secret: System.get_env("CONSOLE_STATS_SECRET")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # Configure your database
 config :cargo_elixir, CargoElixir.Repo,

--- a/lib/cargo_elixir_web/gettext.ex
+++ b/lib/cargo_elixir_web/gettext.ex
@@ -20,5 +20,5 @@ defmodule CargoElixirWeb.Gettext do
 
   See the [Gettext Docs](https://hexdocs.pm/gettext) for detailed usage.
   """
-  use Gettext, otp_app: :cargo_elixir
+  use Gettext.Backend, otp_app: :cargo_exlir
 end


### PR DESCRIPTION
Cargo has long displayed every device which feeds data to it, commonly resulting in a _large number of duplicated devices and very slow load times.

This PR proposed filtering the device list based on the the `name` attribute of the devices to include just a single entry for each.

As an example: `RAK5205-1-phil` has dozens and dozens and dozens of entries all reporting the same location for the given device name.

Using `RAK5205-1-phil` as an example: Inspecting the incoming data there are two fields of interest (subsection of data provided below) the `name` and the `device_id` (`device_id` randomized for clarity, and other fields omitted)

```json
[
  {
    "name": "RAK5205-1-phil",
    ...
    "device_id": "12345678-1234-1234-1234-1234567891011",
    ...
  }
]


[
  {
    "name": "RAK5205-1-phil",
    ...
    "device_id": "ABCDEFGH-ABCD-ABCD-ABCD-ABCDEFGHIJKL"
    ...
  }
]
```

trying to avoid this 🫨 
<img width="366" alt="cargo-crazy" src="https://github.com/user-attachments/assets/79e36ebc-2a33-4f64-95db-a8527abb8fd9">
